### PR TITLE
add route for daily summary and all food consumed in day

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -7,6 +7,7 @@ from app.food import router as food_router
 from app.food_log import router as food_log_router
 from app.middleware import RedisMiddleware
 from app.serving_size import router as serving_size_router
+from app.summary import router as summary_router
 from app.db import Base  # noqa
 
 
@@ -34,6 +35,11 @@ def include_routers(app: FastAPI) -> None:
         serving_size_router,
         prefix='/serving-sizes',
         tags=['serving-sizes'],
+    )
+    app.include_router(
+        summary_router,
+        prefix='/summaries',
+        tags=['summaries']
     )
 
 

--- a/backend/app/food_log/models.py
+++ b/backend/app/food_log/models.py
@@ -1,7 +1,10 @@
 from app.db import Base
 from app.db.mixins import IdMixin
 
-from sqlalchemy import Column, ForeignKey, UUID, String, Float, Date, Enum
+from sqlalchemy import Column, ForeignKey, UUID, Float, Date, Enum
+from sqlalchemy.orm import relationship
+
+from app.serving_size.models import ServingSize
 
 from .enums import MealEnum
 
@@ -25,3 +28,4 @@ class FoodLog(IdMixin, Base):
         Enum(MealEnum),
         default=MealEnum.BREAKFAST,
     )
+    serving_size = relationship(ServingSize, uselist=False)

--- a/backend/app/food_log/routes.py
+++ b/backend/app/food_log/routes.py
@@ -7,22 +7,19 @@ from pydantic import UUID4
 from app.deps import DbSession
 
 from . import router
-from .schemas import FoodLogUpdate, FoodLogRead, FoodLogCreate
+from .schemas import FoodLogUpdate, FoodLogRead, FoodLogCreate, FoodLogNestedRead
 from .services import FoodLogServiceDep
 
 
 @router.get(
     '',
-    response_model=list[FoodLogRead],
+    response_model=list[FoodLogNestedRead],
 )
 async def get_all_by_user_id(
     food_log_service: FoodLogServiceDep,
-    date: Annotated[datetime.date | None, Query()] = None
+    date: Annotated[datetime.date | None, Query()] = datetime.date.today()
 ):
-    if date is None:
-        return await food_log_service.get_all_by_user_id()
-    else:
-        return await food_log_service.get_by_date(date=date)
+    return await food_log_service.get_nested_by_date(date=date)
 
 
 @router.post(

--- a/backend/app/food_log/schemas.py
+++ b/backend/app/food_log/schemas.py
@@ -2,6 +2,9 @@ import datetime
 
 from pydantic import BaseModel, UUID4
 
+from app.serving_size.schemas import ServingSizeNestedRead
+
+
 from .enums import MealEnum
 
 
@@ -25,3 +28,13 @@ class FoodLogCreate(BaseModel):
     serving_count: float
     date: datetime.date
     meal: MealEnum
+
+
+class FoodLogNestedRead(BaseModel):
+
+    id: UUID4
+    serving_count: float
+    date: datetime.date
+    meal: MealEnum
+
+    serving_size: ServingSizeNestedRead

--- a/backend/app/serving_size/models.py
+++ b/backend/app/serving_size/models.py
@@ -1,7 +1,10 @@
-from app.db import Base
-from app.db.mixins import IdMixin
 
 from sqlalchemy import Column, Float, UUID, ForeignKey, String
+from sqlalchemy.orm import relationship
+
+from app.db import Base
+from app.db.mixins import IdMixin
+from app.food.models import Food
 
 
 class ServingSize(IdMixin, Base):
@@ -11,5 +14,6 @@ class ServingSize(IdMixin, Base):
         index=True,
         nullable=False
     )
+    food = relationship(Food, uselist=False)
     name = Column(String, nullable=False)
     ratio = Column(Float, nullable=False)

--- a/backend/app/serving_size/schemas.py
+++ b/backend/app/serving_size/schemas.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, UUID4
+from app.food.schemas import FoodRead
 
 
 class ServingSizeRead(BaseModel):
@@ -6,3 +7,9 @@ class ServingSizeRead(BaseModel):
     food_id: UUID4
     name: str
     ratio: float
+
+
+class ServingSizeNestedRead(BaseModel):
+    name: str
+    ratio: float
+    food: FoodRead

--- a/backend/app/summary/__init__.py
+++ b/backend/app/summary/__init__.py
@@ -1,0 +1,6 @@
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+from .routes import *  # noqa

--- a/backend/app/summary/routes.py
+++ b/backend/app/summary/routes.py
@@ -4,12 +4,18 @@ from typing import Annotated
 from fastapi import Query
 
 from . import router
+from .schemas import row_to_nutrition_summary, NutritionSummary
 from .services import SummaryServiceDep
 
 
-@router.get('/total')
+@router.get(
+    '/total',
+    response_model=NutritionSummary,
+)
 async def total_summary(
     summary_service: SummaryServiceDep,
-    date: Annotated[datetime.date, Query()],
+    date: Annotated[datetime.date | None, Query()] = datetime.date.today(),
 ):
-    return await summary_service.get_total_by_date(date=date)
+    if row := await summary_service.get_total_by_date(date=date):
+        return row_to_nutrition_summary(date=date, row=row)
+    return None

--- a/backend/app/summary/routes.py
+++ b/backend/app/summary/routes.py
@@ -1,0 +1,15 @@
+import datetime
+from typing import Annotated
+
+from fastapi import Query
+
+from . import router
+from .services import SummaryServiceDep
+
+
+@router.get('/total')
+async def total_summary(
+    summary_service: SummaryServiceDep,
+    date: Annotated[datetime.date, Query()],
+):
+    return await summary_service.get_total_by_date(date=date)

--- a/backend/app/summary/schemas.py
+++ b/backend/app/summary/schemas.py
@@ -1,5 +1,6 @@
 import datetime
 from pydantic import BaseModel
+from sqlalchemy import Row
 
 
 class NutritionSummary(BaseModel):
@@ -20,3 +21,25 @@ class NutritionSummary(BaseModel):
     vitamin_c: float | None = None
     calcium: float | None = None
     iron: float | None = None
+
+
+def row_to_nutrition_summary(date: datetime.date, row: Row) -> NutritionSummary:
+    return NutritionSummary(
+        date=date,
+        calories=row[0],
+        total_fat=row[1],
+        saturated_fat=row[2],
+        polyunsaturated_fat=row[3],
+        monounsaturated_fat=row[4],
+        trans_fat=row[5],
+        sodium=row[6],
+        potassium=row[7],
+        total_carbs=row[8],
+        dietary_fiber=row[9],
+        sugars=row[10],
+        protein=row[11],
+        vitamin_a=row[12],
+        vitamin_c=row[13],
+        calcium=row[14],
+        iron=row[15]
+    )

--- a/backend/app/summary/schemas.py
+++ b/backend/app/summary/schemas.py
@@ -1,0 +1,22 @@
+import datetime
+from pydantic import BaseModel
+
+
+class NutritionSummary(BaseModel):
+    date: datetime.date
+    calories: float | None = None
+    total_fat: float | None = None
+    saturated_fat: float | None = None
+    polyunsaturated_fat: float | None = None
+    monounsaturated_fat: float | None = None
+    trans_fat: float | None = None
+    sodium: float | None = None
+    potassium: float | None = None
+    total_carbs: float | None = None
+    dietary_fiber: float | None = None
+    sugars: float | None = None
+    protein: float | None = None
+    vitamin_a: float | None = None
+    vitamin_c: float | None = None
+    calcium: float | None = None
+    iron: float | None = None

--- a/backend/app/summary/services.py
+++ b/backend/app/summary/services.py
@@ -1,0 +1,115 @@
+import datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import Depends
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.deps import CurrentUserId
+from app.deps import DbSession
+from app.food import Food
+from app.food_log import FoodLog
+from app.serving_size import ServingSize
+
+from .schemas import NutritionSummary
+
+
+class SummaryService:
+    def __init__(self, db_session: AsyncSession, user_id: UUID):
+        self.db_session = db_session
+        self.user_id = user_id
+
+    async def get_total_by_date(self, *, date: datetime.date) -> NutritionSummary:
+
+        query = select(
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.calories
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.total_fat
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.saturated_fat
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.polyunsaturated_fat
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.monounsaturated_fat
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.trans_fat
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.sodium
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.potassium
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.total_carbs
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.dietary_fiber
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.sugars
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.protein
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.vitamin_a
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.vitamin_c
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.calcium
+            ),
+            func.sum(
+                FoodLog.serving_count * ServingSize.ratio * Food.iron
+            ),
+        ).join(
+            ServingSize, ServingSize.id == FoodLog.serving_size_id
+        ).join(
+            Food, Food.id == ServingSize.food_id
+        ).where(
+            FoodLog.date == date,
+            FoodLog.user_id == self.user_id,
+        )
+
+        result = (await self.db_session.execute(query)).one_or_none()
+
+        daily_summary = NutritionSummary(
+            date=date,
+            calories=result[0],
+            total_fat=result[1],
+            saturated_fat=result[2],
+            polyunsaturated_fat=result[3],
+            monounsaturated_fat=result[4],
+            trans_fat=result[5],
+            sodium=result[6],
+            potassium=result[7],
+            total_carbs=result[8],
+            dietary_fiber=result[9],
+            sugars=result[10],
+            protein=result[11],
+            vitamin_a=result[12],
+            vitamin_c=result[13],
+            calcium=result[14],
+            iron=result[15]
+        )
+
+        return daily_summary
+
+    async def get_food_by_date(self, *, date: datetime.date):
+        pass
+
+
+def get_summary_service(db_session: DbSession, current_user_id: CurrentUserId):
+    return SummaryService(db_session=db_session, user_id=current_user_id)
+
+
+SummaryServiceDep = Annotated[SummaryService, Depends(get_summary_service)]

--- a/backend/app/summary/services.py
+++ b/backend/app/summary/services.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends
-from sqlalchemy import select, func
+from sqlalchemy import select, func, Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.deps import CurrentUserId
@@ -12,15 +12,13 @@ from app.food import Food
 from app.food_log import FoodLog
 from app.serving_size import ServingSize
 
-from .schemas import NutritionSummary
-
 
 class SummaryService:
     def __init__(self, db_session: AsyncSession, user_id: UUID):
         self.db_session = db_session
         self.user_id = user_id
 
-    async def get_total_by_date(self, *, date: datetime.date) -> NutritionSummary:
+    async def get_total_by_date(self, *, date: datetime.date) -> Row | None:
 
         query = select(
             func.sum(
@@ -80,29 +78,7 @@ class SummaryService:
             FoodLog.user_id == self.user_id,
         )
 
-        result = (await self.db_session.execute(query)).one_or_none()
-
-        daily_summary = NutritionSummary(
-            date=date,
-            calories=result[0],
-            total_fat=result[1],
-            saturated_fat=result[2],
-            polyunsaturated_fat=result[3],
-            monounsaturated_fat=result[4],
-            trans_fat=result[5],
-            sodium=result[6],
-            potassium=result[7],
-            total_carbs=result[8],
-            dietary_fiber=result[9],
-            sugars=result[10],
-            protein=result[11],
-            vitamin_a=result[12],
-            vitamin_c=result[13],
-            calcium=result[14],
-            iron=result[15]
-        )
-
-        return daily_summary
+        return (await self.db_session.execute(query)).one_or_none()
 
     async def get_food_by_date(self, *, date: datetime.date):
         pass


### PR DESCRIPTION
Added `/summaries/total` route to return sum of calories/nutrients for given date. Update `/food-logs` route to include nested serving size and food objects.

![image](https://github.com/user-attachments/assets/902a9743-73f8-4b87-bb79-89af48104a8c)
![image](https://github.com/user-attachments/assets/f1b2df28-0b7e-458e-a022-26be305ac6e1)
